### PR TITLE
Hotfix, increment version to 0.1.3

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: MVQuickGraphs
 Type: Package
 Title: Quick Multivariate Graphs
-Version: 0.1.2
+Version: 0.1.3
 Author: Douglas Whitaker
 Maintainer: Douglas Whitaker <douglas.whitaker@msvu.ca>
 Description: Functions used for graphing in multivariate contexts. These 

--- a/R/ellipse-functions.R
+++ b/R/ellipse-functions.R
@@ -72,7 +72,7 @@ bvNormalContour <- function(mu = c(0,0), Sigma=NULL, eig=NULL,
 
   # Critical value for the constant density contour (always df=2 because this is bivariate normal)
   # Johnson & Wichern (2008) result (4-8)
-  clevel <- qchisq(1 - alpha, df = 2)
+  clevel <- sqrt(qchisq(1 - alpha, df = 2))
 
   # User needs to supply either eig or Sigma
   if (!is.null(Sigma)){

--- a/ignore/release-notes.txt
+++ b/ignore/release-notes.txt
@@ -1,0 +1,7 @@
+Release Notes
+
+Version 0.1.3
+* Hotfix for typo in bvNormalContour (missed a square root, affecting results)
+
+Version 0.1.2
+First public release

--- a/ignore/testing.R
+++ b/ignore/testing.R
@@ -1,0 +1,9 @@
+# Testing hotfix for c value
+
+bvNormalContour(Sigma=matrix(c(1,0,0,1),nrow=2))
+bvNormalContour(Sigma=matrix(c(1,0,0,1),nrow=2),alpha=0.1)
+bvNormalContour(Sigma=matrix(c(1,0,0,1),nrow=2),alpha=0.5)
+
+bvNormalContour(mu=c(0,2),Sigma=matrix(c(2,1/sqrt(2),1/sqrt(2),1),nrow=2),alpha=0.5)
+bvNormalContour(mu=c(5,10),Sigma=matrix(c(9,16,16,64),nrow=2),alpha=0.05)
+points(x=10.273,y=29.551)

--- a/ignore/to-do.txt
+++ b/ignore/to-do.txt
@@ -3,3 +3,4 @@ To do:
     https://www.probabilitycourse.com/chapter5/5_1_1_joint_pmf.php
   Check to see if Chernoff faces over time is easily supported in aplpack
     (Johnson & Wichern example 1.13)
+  A person-item map that looks like a Wright Map? (Rasch analysis)


### PR DESCRIPTION
There was an error in the calculation of the c value - the square root was missing in either location that it would make sense to have it. This made the results of bvNormalContour much wider than they should have been.